### PR TITLE
バックグラウンド監視・通知機能追加

### DIFF
--- a/client/android/app/build.gradle.kts
+++ b/client/android/app/build.gradle.kts
@@ -21,6 +21,7 @@ android {
     ndkVersion = "27.0.12077973"
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -125,6 +126,7 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api:1.3.2")
     implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
     implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }
 
 protobuf {

--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="DMS"
         android:name="${applicationName}"

--- a/client/lib/config.dart
+++ b/client/lib/config.dart
@@ -1,5 +1,9 @@
 /// アプリのデフォルト設定値を一元管理
 class AppConfig {
+  static const double defaultDecibelThreshold = 70.0;
+  static const int defaultAutoWatchIntervalSec =
+      900; // 15分(Android WorkManagerの最小値)
+
   static const String defaultHost = '10.0.2.2';
   static const int defaultPort = 50051;
   static const String defaultAccessToken = '';

--- a/client/lib/settings_service.dart
+++ b/client/lib/settings_service.dart
@@ -33,6 +33,41 @@ class ConnectionConfig {
 }
 
 class SettingsService {
+  static const _decibelThresholdKey = 'decibelThreshold';
+  Future<double> getDecibelThreshold() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getDouble(_decibelThresholdKey) ??
+        AppConfig.defaultDecibelThreshold;
+  }
+
+  Future<void> setDecibelThreshold(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_decibelThresholdKey, value);
+  }
+
+  static const _autoWatchEnabledKey = 'autoWatchEnabled';
+  static const _autoWatchIntervalSecKey = 'autoWatchIntervalSec';
+  Future<bool> getAutoWatchEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_autoWatchEnabledKey) ?? false;
+  }
+
+  Future<void> setAutoWatchEnabled(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_autoWatchEnabledKey, enabled);
+  }
+
+  Future<int> getAutoWatchIntervalSec() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_autoWatchIntervalSecKey) ??
+        AppConfig.defaultAutoWatchIntervalSec;
+  }
+
+  Future<void> setAutoWatchIntervalSec(int sec) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_autoWatchIntervalSecKey, sec);
+  }
+
   static const _configsKey = 'connectionConfigs';
   static const _selectedIndexKey = 'selectedConfigIndex';
 

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -43,6 +43,9 @@ dependencies:
   provider: ^6.1.2
   shared_preferences: ^2.5.3
   flutter_launcher_icons: ^0.14.4
+  workmanager: ^0.7.0
+  flutter_local_notifications: ^19.4.0
+  permission_handler: ^11.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
バックグラウンド監視の処理でWorkManagerを使用している関係上、
最短でも15分間隔監視となります。
通知の管理を行っていないため、バックグラウンド処理のオンオフを繰り返したり、
アプリの再起動を繰り返したりした場合は、通知が再度表示されることがあります。
(現在時間-監視間隔時間から現在時間までの範囲を閾値でチェックするため)

デシベル値が閾値を超えた際、直ぐに通知するにはサーバー側で処理する必要があります。
現状のgRPC通信はUnary RPC（単方向通信）を使用してるので、通知部分だけ
Server Streaming RPC（サーバストリーミング通信）か
Bidirectional Streaming RPC（双方向ストリーミング通信）で
実装する必要があります。
