### PR TITLE
Settings encryption support

### DIFF
--- a/client/lib/config.dart
+++ b/client/lib/config.dart
@@ -13,4 +13,16 @@ class AppConfig {
   static const String title = 'Decibel Log Viewer';
   static const String dateTimeFormat = 'yyyy/MM/dd HH:mm:ss';
   static const String inputCalendarFormat = 'yyyy/MM/dd HH:mm';
+  // 暗号化キー（32文字=256bit）: 環境変数 DECIBEL_ENCRYPTION_KEY から取得
+  static const int encryptionKeyLength = 32;
+  static String get encryptionKey {
+    const defaultKey = ''; // 暗号化キー空は平文処理
+    final envKey = const String.fromEnvironment('DECIBEL_ENCRYPTION_KEY');
+    if (envKey.isNotEmpty && envKey.length >= 16) {
+      return envKey
+          .padRight(encryptionKeyLength, '0')
+          .substring(0, encryptionKeyLength);
+    }
+    return defaultKey;
+  }
 }

--- a/client/lib/config.dart
+++ b/client/lib/config.dart
@@ -18,10 +18,8 @@ class AppConfig {
   static String get encryptionKey {
     const defaultKey = ''; // 暗号化キー空は平文処理
     final envKey = const String.fromEnvironment('DECIBEL_ENCRYPTION_KEY');
-    if (envKey.isNotEmpty && envKey.length >= 16) {
-      return envKey
-          .padRight(encryptionKeyLength, '0')
-          .substring(0, encryptionKeyLength);
+    if (envKey.isNotEmpty && envKey.length >= encryptionKeyLength) {
+      return envKey.substring(0, encryptionKeyLength);
     }
     return defaultKey;
   }

--- a/client/lib/settings_page.dart
+++ b/client/lib/settings_page.dart
@@ -13,6 +13,8 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
+  // 各接続先ごとにアクセストークン表示/非表示状態を管理
+  final List<bool> _obscureAccessTokenList = [];
   final TextEditingController _pinClusterRadiusController =
       TextEditingController();
   double _pinClusterRadius = AppConfig.defaultPinClusterRadiusMeter;
@@ -87,6 +89,7 @@ class _SettingsPageState extends State<SettingsPage> {
         ),
       );
       _selectedIndex = _configs.length - 1;
+      _obscureAccessTokenList.add(true);
     });
   }
 
@@ -94,6 +97,7 @@ class _SettingsPageState extends State<SettingsPage> {
     if (_configs.length <= 1) return;
     setState(() {
       _configs.removeAt(idx);
+      _obscureAccessTokenList.removeAt(idx);
       if (_selectedIndex >= _configs.length) {
         _selectedIndex = _configs.length - 1;
       }
@@ -143,8 +147,31 @@ class _SettingsPageState extends State<SettingsPage> {
               onChanged: (v) => config.port = int.tryParse(v) ?? 50051,
             ),
             TextField(
-              decoration: const InputDecoration(labelText: 'アクセストークン'),
               controller: TextEditingController(text: config.accessToken),
+              obscureText:
+                  _obscureAccessTokenList.length > idx
+                      ? _obscureAccessTokenList[idx]
+                      : true,
+              decoration: InputDecoration(
+                labelText: 'アクセストークン',
+                hintText: 'APIアクセストークンを入力',
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscureAccessTokenList.length > idx &&
+                            _obscureAccessTokenList[idx]
+                        ? Icons.visibility
+                        : Icons.visibility_off,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      if (_obscureAccessTokenList.length > idx) {
+                        _obscureAccessTokenList[idx] =
+                            !_obscureAccessTokenList[idx];
+                      }
+                    });
+                  },
+                ),
+              ),
               onChanged: (v) => config.accessToken = v,
             ),
             TextField(

--- a/client/lib/settings_page.dart
+++ b/client/lib/settings_page.dart
@@ -44,7 +44,15 @@ class _SettingsPageState extends State<SettingsPage> {
   int _selectedIndex = 0;
 
   Future<void> _load() async {
-    final configs = await _settings.getConfigs();
+    final configs = await _settings.getConfigs(
+      onError: (msg) {
+        if (mounted) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(msg)));
+        }
+      },
+    );
     final idx = await _settings.getSelectedConfigIndex();
     final enabled = await _settings.getAutoWatchEnabled();
     final interval = await _settings.getAutoWatchIntervalSec();
@@ -62,6 +70,9 @@ class _SettingsPageState extends State<SettingsPage> {
       _showGps = showGps;
       _pinClusterRadius = pinClusterRadius;
       _pinClusterRadiusController.text = pinClusterRadius.toString();
+      // _obscureAccessTokenListの長さをconfigsに合わせて初期化
+      _obscureAccessTokenList.clear();
+      _obscureAccessTokenList.addAll(List<bool>.filled(configs.length, true));
     });
   }
 

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   flutter_local_notifications: ^19.4.0
   permission_handler: ^11.3.1
   encrypt: ^5.0.3
+  cryptography: ^2.7.0
 
 dev_dependencies:
   flutter_test:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   workmanager: ^0.7.0
   flutter_local_notifications: ^19.4.0
   permission_handler: ^11.3.1
+  encrypt: ^5.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
copilotレビュー対応
特殊ルート(*1)で設定ファイルを読み込むとエラーになるためメッセージ表示

*1 一度暗号化した設定情報を保存した後に、平文で設定情報を読み込むパターン
通常はビルド時に平文か暗号化するかを固定するので特殊ルートになることはないが、
開発環境では可能なため対応