### PR TITLE
Update license file path to include .txt extension

### DIFF
--- a/client/lib/license_list_page.dart
+++ b/client/lib/license_list_page.dart
@@ -64,7 +64,7 @@ class LicenseListPage extends StatelessWidget {
                   String licenseText = '';
                   String filePath = '';
                   if (fileName.isNotEmpty) {
-                    filePath = 'assets/licenses/$fileName';
+                    filePath = 'assets/licenses/$fileName.txt';
                   } else {
                     filePath = 'assets/licenses/$licenseName.txt';
                   }


### PR DESCRIPTION
テク数ライセンスで優先するライセンス表示を行う場合に.txt拡張子を忘れていた不具合修正